### PR TITLE
Corrige integridade de mensagens diretas e reconciliação de conversas (com cobertura PostgreSQL)

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -12,6 +12,53 @@ permissions:
   contents: read
 
 jobs:
+  direct-messages-postgres:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: pixelfed_test
+          POSTGRES_USER: pixelfed
+          POSTGRES_PASSWORD: pixelfed
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U pixelfed -d pixelfed_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      APP_ENV: testing
+      APP_KEY: base64:2rK9gO0V1xgJgQFfJYgMCdTWwFQ5WzD3U+shWOZy3WU=
+      CACHE_DRIVER: array
+      DB_CONNECTION: pgsql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 5432
+      DB_DATABASE: pixelfed_test
+      DB_USERNAME: pixelfed
+      DB_PASSWORD: pixelfed
+      FILESYSTEM_DISK: local
+      QUEUE_DRIVER: sync
+      SESSION_DRIVER: array
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pgsql, pdo_pgsql, bcmath, soap, intl, gd, exif, iconv
+          coverage: none
+
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Test direct messages on PostgreSQL
+        run: php artisan test tests/Feature/DirectMessageIntegrityTest.php
+
   tests:
     runs-on: ubuntu-latest
     env:

--- a/app/Console/Commands/RepairDirectMessages.php
+++ b/app/Console/Commands/RepairDirectMessages.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\DirectMessage;
+use App\Models\Conversation;
+use App\Services\DirectMessageService;
+use Illuminate\Console\Command;
+
+class RepairDirectMessages extends Command
+{
+    protected $signature = 'pixelfed:repair-direct-messages {--dry-run : Report inconsistencies without changing data}';
+
+    protected $description = 'Diagnose and repair orphan direct messages and invalid conversation metadata';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $stats = [
+            'orphan_found' => 0,
+            'orphan_repaired' => 0,
+            'orphan_removed' => 0,
+            'conversations_repaired' => 0,
+            'invalid_conversations_removed' => 0,
+            'duplicates_removed' => 0,
+        ];
+
+        DirectMessage::query()
+            ->whereNotExists(function ($query) {
+                $query->selectRaw('1')
+                    ->from('statuses')
+                    ->whereColumn('statuses.id', 'direct_messages.status_id')
+                    ->whereNull('statuses.deleted_at');
+            })
+            ->orderBy('id')
+            ->chunkById(100, function ($dms) use ($dryRun, &$stats) {
+                foreach ($dms as $dm) {
+                    $stats['orphan_found']++;
+                    DirectMessageService::logOrphan($dm);
+
+                    if ($dryRun) {
+                        continue;
+                    }
+
+                    DirectMessageService::deleteDm($dm);
+                    $stats['orphan_removed']++;
+                }
+            });
+
+        Conversation::query()->orderBy('id')->chunkById(100, function ($conversations) use ($dryRun, &$stats) {
+            foreach ($conversations as $conversation) {
+                $latest = DirectMessage::query()
+                    ->whereFromId($conversation->from_id)
+                    ->whereToId($conversation->to_id)
+                    ->whereHas('status')
+                    ->orderByDesc('id')
+                    ->first();
+
+                if (! $latest) {
+                    $stats['invalid_conversations_removed']++;
+                    if (! $dryRun) {
+                        $conversation->delete();
+                    }
+
+                    continue;
+                }
+
+                $invalid = (string) $conversation->dm_id !== (string) $latest->id
+                    || (string) $conversation->status_id !== (string) $latest->status_id
+                    || $conversation->type !== $latest->type
+                    || (bool) $conversation->is_hidden !== (bool) $latest->is_hidden;
+
+                if ($invalid) {
+                    $stats['conversations_repaired']++;
+                    if (! $dryRun) {
+                        DirectMessageService::updateConversation($latest, true);
+                    }
+                }
+            }
+        });
+
+        $duplicates = Conversation::query()
+            ->select('from_id', 'to_id')
+            ->selectRaw('COUNT(*) AS aggregate')
+            ->groupBy('from_id', 'to_id')
+            ->havingRaw('COUNT(*) > 1')
+            ->get();
+
+        foreach ($duplicates as $duplicate) {
+            $rows = Conversation::whereFromId($duplicate->from_id)
+                ->whereToId($duplicate->to_id)
+                ->orderByDesc('id')
+                ->get();
+            $stats['duplicates_removed'] += max(0, $rows->count() - 1);
+            if (! $dryRun) {
+                $rows->skip(1)->each->delete();
+                DirectMessageService::reconcileDirection($duplicate->from_id, $duplicate->to_id);
+            }
+        }
+
+        $this->table(['Metric', 'Count'], [
+            ['Orphan DMs found', $stats['orphan_found']],
+            ['Orphan DMs repaired', $stats['orphan_repaired']],
+            ['Orphan DMs removed', $stats['orphan_removed']],
+            ['Conversations repaired', $stats['conversations_repaired']],
+            ['Invalid conversation references removed', $stats['invalid_conversations_removed']],
+            ['Duplicate conversations removed', $stats['duplicates_removed']],
+        ]);
+        $this->info($dryRun ? 'Dry run complete; no data was changed.' : 'Direct message repair complete.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/DirectMessage.php
+++ b/app/DirectMessage.php
@@ -2,11 +2,44 @@
 
 namespace App;
 
+use App\Services\DirectMessageService;
 use Auth;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use LogicException;
 
 class DirectMessage extends Model
 {
+    protected static function booted(): void
+    {
+        static::creating(function (DirectMessage $dm) {
+            if (! Status::whereKey($dm->status_id)->exists()) {
+                throw new LogicException('A direct message must reference an existing status.');
+            }
+        });
+
+        static::saved(function (DirectMessage $dm) {
+            DirectMessageService::updateConversation($dm);
+        });
+
+        static::deleted(function (DirectMessage $dm) {
+            DirectMessageService::reconcileBetween($dm->from_id, $dm->to_id);
+        });
+    }
+
+    public function scopeBetweenProfiles(Builder $query, $firstProfileId, $secondProfileId): Builder
+    {
+        return $query->where(function (Builder $query) use ($firstProfileId, $secondProfileId) {
+            $query->where(function (Builder $query) use ($firstProfileId, $secondProfileId) {
+                $query->where('from_id', $firstProfileId)
+                    ->where('to_id', $secondProfileId);
+            })->orWhere(function (Builder $query) use ($firstProfileId, $secondProfileId) {
+                $query->where('from_id', $secondProfileId)
+                    ->where('to_id', $firstProfileId);
+            });
+        });
+    }
+
     public function status()
     {
         return $this->belongsTo(Status::class, 'status_id', 'id');

--- a/app/Http/Controllers/Api/ApiV1Controller.php
+++ b/app/Http/Controllers/Api/ApiV1Controller.php
@@ -35,7 +35,6 @@ use App\Jobs\StatusPipeline\StatusDelete;
 use App\Jobs\VideoPipeline\VideoThumbnail;
 use App\Like;
 use App\Media;
-use App\Models\Conversation;
 use App\Models\CustomFilter;
 use App\Notification;
 use App\Profile;
@@ -3268,45 +3267,30 @@ class ApiV1Controller extends Controller
             return [];
         }
 
-        $pid = $user->profile_id;
+        $pid = (int) $user->profile_id;
 
-        $isPgsql = config('database.default') == 'pgsql';
+        $counterpart = $scope === 'sent'
+            ? 'to_id'
+            : ($scope === 'requests'
+                ? 'from_id'
+                : "CASE WHEN from_id = {$pid} THEN to_id ELSE from_id END");
 
-        if ($isPgsql) {
-            $dms = DirectMessage::when($scope === 'inbox', function ($q) use ($pid) {
-                return $q->whereIsHidden(false)
+        $ranked = DirectMessage::query()
+            ->select('direct_messages.*')
+            ->selectRaw("ROW_NUMBER() OVER (PARTITION BY {$counterpart} ORDER BY id DESC) AS conversation_rank")
+            ->whereHas('status')
+            ->when($scope === 'inbox', function ($query) use ($pid) {
+                $query->whereIsHidden(false)
                     ->where(function ($query) use ($pid) {
-                        $query->where('to_id', $pid)
-                            ->orWhere('from_id', $pid);
+                        $query->whereToId($pid)->orWhere('from_id', $pid);
                     });
             })
-                ->when($scope === 'sent', function ($q) use ($pid) {
-                    return $q->whereFromId($pid)
-                        ->groupBy(['to_id', 'id']);
-                })
-                ->when($scope === 'requests', function ($q) use ($pid) {
-                    return $q->whereToId($pid)
-                        ->whereIsHidden(true);
-                });
-        } else {
-            $dms = Conversation::when($scope === 'inbox', function ($q) use ($pid) {
-                return $q->whereIsHidden(false)
-                    ->where(function ($query) use ($pid) {
-                        $query->where('to_id', $pid)
-                            ->orWhere('from_id', $pid);
-                    })
-                    ->orderByDesc('status_id')
-                    ->groupBy(['to_id', 'from_id']);
-            })
-                ->when($scope === 'sent', function ($q) use ($pid) {
-                    return $q->whereFromId($pid)
-                        ->groupBy('to_id');
-                })
-                ->when($scope === 'requests', function ($q) use ($pid) {
-                    return $q->whereToId($pid)
-                        ->whereIsHidden(true);
-                });
-        }
+            ->when($scope === 'sent', fn ($query) => $query->whereFromId($pid))
+            ->when($scope === 'requests', fn ($query) => $query->whereToId($pid)->whereIsHidden(true));
+
+        $dms = DirectMessage::query()
+            ->fromSub($ranked, 'direct_messages')
+            ->where('conversation_rank', 1);
 
         if ($min_id) {
             $dms = $dms->where('id', '>', $min_id);
@@ -3318,7 +3302,7 @@ class ApiV1Controller extends Controller
             $dms = $dms->where('id', '>', $since_id);
         }
 
-        $dms = $dms->orderByDesc('status_id')->orderBy('id');
+        $dms = $dms->orderByDesc('id');
 
         $dmResults = $dms->limit($limit + 1)->get();
 
@@ -3347,9 +3331,6 @@ class ApiV1Controller extends Controller
                     && count($dm['accounts'])
                     && isset($dm['accounts'][0])
                     && isset($dm['accounts'][0]['id']);
-            })
-            ->unique(function ($item) {
-                return $item['accounts'][0]['id'];
             })
             ->values();
 

--- a/app/Http/Controllers/DirectMessageController.php
+++ b/app/Http/Controllers/DirectMessageController.php
@@ -7,15 +7,14 @@ use App\Jobs\DirectPipeline\DirectDeletePipeline;
 use App\Jobs\DirectPipeline\DirectDeliverPipeline;
 use App\Jobs\StatusPipeline\StatusDelete;
 use App\Media;
-use App\Models\Conversation;
 use App\Notification;
 use App\Profile;
 use App\Services\AccountService;
+use App\Services\DirectMessageService;
 use App\Services\FollowerService;
 use App\Services\MediaBlocklistService;
 use App\Services\MediaPathService;
 use App\Services\MediaService;
-use App\Services\StatusService;
 use App\Services\UserFilterService;
 use App\Services\UserRoleService;
 use App\Services\UserStorageService;
@@ -25,6 +24,7 @@ use App\UserFilter;
 use App\Util\ActivityPub\Helpers;
 use App\Util\Lexer\Autolink;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class DirectMessageController extends Controller
@@ -52,54 +52,27 @@ class DirectMessageController extends Controller
         $limit = 8;
         $offset = ($page - 1) * $limit;
 
-        $baseQuery = DirectMessage::select(
-            'id', 'type', 'to_id', 'from_id', 'status_id',
-            'is_hidden', 'meta', 'created_at', 'read_at'
-        )->with(['author', 'status', 'recipient']);
+        $partition = $action === 'sent' ? 'to_id' : 'from_id';
+        $ranked = DirectMessage::query()
+            ->select('direct_messages.*')
+            ->selectRaw("ROW_NUMBER() OVER (PARTITION BY {$partition} ORDER BY id DESC) AS conversation_rank")
+            ->whereHas('status');
 
-        if (config('database.default') == 'pgsql') {
-            $query = match ($action) {
-                'inbox' => $baseQuery->whereToId($profile)
-                    ->whereIsHidden(false)
-                    ->orderBy('created_at', 'desc'),
-                'sent' => $baseQuery->whereFromId($profile)
-                    ->orderBy('created_at', 'desc'),
-                'filtered' => $baseQuery->whereToId($profile)
-                    ->whereIsHidden(true)
-                    ->orderBy('created_at', 'desc'),
-                default => throw new \InvalidArgumentException('Invalid action')
-            };
+        $ranked = match ($action) {
+            'inbox' => $ranked->whereToId($profile)->whereIsHidden(false),
+            'sent' => $ranked->whereFromId($profile),
+            'filtered' => $ranked->whereToId($profile)->whereIsHidden(true),
+            default => throw new \InvalidArgumentException('Invalid action'),
+        };
 
-            $dms = $query->offset($offset)
-                ->limit($limit)
-                ->get();
-
-            $dms = $action === 'sent' ?
-                   $dms->unique('to_id') :
-                   $dms->unique('from_id');
-        } else {
-            $query = match ($action) {
-                'inbox' => $baseQuery->whereToId($profile)
-                    ->whereIsHidden(false)
-                    ->groupBy('from_id', 'id', 'type', 'to_id', 'status_id',
-                        'is_hidden', 'meta', 'created_at', 'read_at')
-                    ->orderBy('created_at', 'desc'),
-                'sent' => $baseQuery->whereFromId($profile)
-                    ->groupBy('to_id', 'id', 'type', 'from_id', 'status_id',
-                        'is_hidden', 'meta', 'created_at', 'read_at')
-                    ->orderBy('created_at', 'desc'),
-                'filtered' => $baseQuery->whereToId($profile)
-                    ->whereIsHidden(true)
-                    ->groupBy('from_id', 'id', 'type', 'to_id', 'status_id',
-                        'is_hidden', 'meta', 'created_at', 'read_at')
-                    ->orderBy('created_at', 'desc'),
-                default => throw new \InvalidArgumentException('Invalid action')
-            };
-
-            $dms = $query->offset($offset)
-                ->limit($limit)
-                ->get();
-        }
+        $dms = DirectMessage::query()
+            ->fromSub($ranked, 'direct_messages')
+            ->with(['author', 'status', 'recipient'])
+            ->where('conversation_rank', 1)
+            ->orderByDesc('id')
+            ->offset($offset)
+            ->limit($limit)
+            ->get();
 
         $mappedDms = $dms->map(function ($r) use ($action) {
             if ($action === 'sent') {
@@ -165,34 +138,25 @@ class DirectMessageController extends Controller
             $hidden = false;
         }
 
-        $status = new Status;
-        $status->profile_id = $profile->id;
-        $status->caption = $msg;
-        $status->visibility = 'direct';
-        $status->scope = 'direct';
-        $status->in_reply_to_profile_id = $recipient->id;
-        $status->save();
+        [$status, $dm] = DB::transaction(function () use ($profile, $recipient, $msg, $hidden, $request) {
+            $status = new Status;
+            $status->profile_id = $profile->id;
+            $status->caption = $msg;
+            $status->visibility = 'direct';
+            $status->scope = 'direct';
+            $status->in_reply_to_profile_id = $recipient->id;
+            $status->save();
 
-        $dm = new DirectMessage;
-        $dm->to_id = $recipient->id;
-        $dm->from_id = $profile->id;
-        $dm->status_id = $status->id;
-        $dm->is_hidden = $hidden;
-        $dm->type = $request->input('type');
-        $dm->save();
+            $dm = new DirectMessage;
+            $dm->to_id = $recipient->id;
+            $dm->from_id = $profile->id;
+            $dm->status_id = $status->id;
+            $dm->is_hidden = $hidden;
+            $dm->type = $request->input('type');
+            $dm->save();
 
-        Conversation::updateOrInsert(
-            [
-                'to_id' => $recipient->id,
-                'from_id' => $profile->id,
-            ],
-            [
-                'type' => $dm->type,
-                'status_id' => $status->id,
-                'dm_id' => $dm->id,
-                'is_hidden' => $hidden,
-            ]
-        );
+            return [$status, $dm];
+        });
 
         if (filter_var($msg, FILTER_VALIDATE_URL)) {
             if (Helpers::validateUrl($msg)) {
@@ -264,6 +228,12 @@ class DirectMessageController extends Controller
 
         $profile = Profile::findOrFail($pid);
 
+        DirectMessage::betweenProfiles($pid, $uid)
+            ->whereDoesntHave('status')
+            ->limit(10)
+            ->get()
+            ->each(fn (DirectMessage $dm) => DirectMessageService::logOrphan($dm));
+
         $query = DirectMessage::select(
             'id',
             'is_hidden',
@@ -274,41 +244,32 @@ class DirectMessageController extends Controller
             'meta',
             'created_at',
             'read_at'
-        )->with(['status']);
+        )->with(['status'])->whereHas('status');
+
+        $query->betweenProfiles($pid, $uid);
 
         if ($min_id) {
             $res = $query->where('id', '>', $min_id)
-                ->where(function ($query) use ($pid, $uid) {
-                    $query->where('from_id', $pid)->where('to_id', $uid);
-                })->orWhere(function ($query) use ($pid, $uid) {
-                    $query->where('from_id', $uid)->where('to_id', $pid);
-                })
                 ->orderBy('id', 'asc')
                 ->take(8)
                 ->get()
                 ->reverse();
         } elseif ($max_id) {
             $res = $query->where('id', '<', $max_id)
-                ->where(function ($query) use ($pid, $uid) {
-                    $query->where('from_id', $pid)->where('to_id', $uid);
-                })->orWhere(function ($query) use ($pid, $uid) {
-                    $query->where('from_id', $uid)->where('to_id', $pid);
-                })
                 ->orderBy('id', 'desc')
                 ->take(8)
                 ->get();
         } else {
-            $res = $query->where(function ($query) use ($pid, $uid) {
-                $query->where('from_id', $pid)->where('to_id', $uid);
-            })->orWhere(function ($query) use ($pid, $uid) {
-                $query->where('from_id', $uid)->where('to_id', $pid);
-            })
-                ->orderBy('id', 'desc')
+            $res = $query->orderBy('id', 'desc')
                 ->take(8)
                 ->get();
         }
 
         $messages = $res->filter(function ($message) {
+            if ($message && ! $message->status) {
+                DirectMessageService::logOrphan($message);
+            }
+
             return $message && $message->status;
         })->map(function ($message) use ($uid) {
             return [
@@ -369,52 +330,11 @@ class DirectMessageController extends Controller
         }
 
         if ($recipient['local'] == false) {
-            $dmc = $dm;
-            $this->remoteDelete($dmc);
-        } else {
-            StatusDelete::dispatch($status)->onQueue('high');
+            $this->remoteDelete($dm);
         }
 
-        if (Conversation::whereStatusId($sid)->count()) {
-            $latest = DirectMessage::where(['from_id' => $dm->from_id, 'to_id' => $dm->to_id])
-                ->orWhere(['to_id' => $dm->from_id, 'from_id' => $dm->to_id])
-                ->latest()
-                ->first();
-
-            if ($latest->status_id == $sid) {
-                Conversation::where(['to_id' => $dm->from_id, 'from_id' => $dm->to_id])
-                    ->update([
-                        'updated_at' => $latest->updated_at,
-                        'status_id' => $latest->status_id,
-                        'type' => $latest->type,
-                        'is_hidden' => false,
-                    ]);
-
-                Conversation::where(['to_id' => $dm->to_id, 'from_id' => $dm->from_id])
-                    ->update([
-                        'updated_at' => $latest->updated_at,
-                        'status_id' => $latest->status_id,
-                        'type' => $latest->type,
-                        'is_hidden' => false,
-                    ]);
-            } else {
-                Conversation::where([
-                    'status_id' => $sid,
-                    'to_id' => $dm->from_id,
-                    'from_id' => $dm->to_id,
-                ])->delete();
-
-                Conversation::where([
-                    'status_id' => $sid,
-                    'from_id' => $dm->from_id,
-                    'to_id' => $dm->to_id,
-                ])->delete();
-            }
-        }
-
-        StatusService::del($status->id, true);
-
-        $status->forceDeleteQuietly();
+        DirectMessageService::deleteDm($dm);
+        StatusDelete::dispatch($status)->onQueue('high');
 
         return [200];
     }
@@ -483,51 +403,42 @@ class DirectMessageController extends Controller
 
         abort_if(MediaBlocklistService::exists($hash) == true, 451);
 
-        $status = new Status;
-        $status->profile_id = $profile->id;
-        $status->caption = null;
-        $status->visibility = 'direct';
-        $status->scope = 'direct';
-        $status->in_reply_to_profile_id = $recipient->id;
-        $status->save();
+        [$status, $media, $dm] = DB::transaction(function () use ($profile, $recipient, $user, $path, $hash, $photo, $hidden, $updatedAccountSize) {
+            $status = new Status;
+            $status->profile_id = $profile->id;
+            $status->caption = null;
+            $status->visibility = 'direct';
+            $status->scope = 'direct';
+            $status->in_reply_to_profile_id = $recipient->id;
+            $status->save();
 
-        $media = new Media;
-        $media->status_id = $status->id;
-        $media->profile_id = $profile->id;
-        $media->user_id = $user->id;
-        $media->media_path = $path;
-        $media->original_sha256 = $hash;
-        $media->size = $photo->getSize();
-        $media->mime = $photo->getMimeType();
-        $media->caption = null;
-        $media->filter_class = null;
-        $media->filter_name = null;
-        $media->save();
+            $media = new Media;
+            $media->status_id = $status->id;
+            $media->profile_id = $profile->id;
+            $media->user_id = $user->id;
+            $media->media_path = $path;
+            $media->original_sha256 = $hash;
+            $media->size = $photo->getSize();
+            $media->mime = $photo->getMimeType();
+            $media->caption = null;
+            $media->filter_class = null;
+            $media->filter_name = null;
+            $media->save();
 
-        $dm = new DirectMessage;
-        $dm->to_id = $recipient->id;
-        $dm->from_id = $profile->id;
-        $dm->status_id = $status->id;
-        $dm->type = array_first(explode('/', $media->mime)) == 'video' ? 'video' : 'photo';
-        $dm->is_hidden = $hidden;
-        $dm->save();
+            $dm = new DirectMessage;
+            $dm->to_id = $recipient->id;
+            $dm->from_id = $profile->id;
+            $dm->status_id = $status->id;
+            $dm->type = array_first(explode('/', $media->mime)) == 'video' ? 'video' : 'photo';
+            $dm->is_hidden = $hidden;
+            $dm->save();
 
-        Conversation::updateOrInsert(
-            [
-                'to_id' => $recipient->id,
-                'from_id' => $profile->id,
-            ],
-            [
-                'type' => $dm->type,
-                'status_id' => $status->id,
-                'dm_id' => $dm->id,
-                'is_hidden' => $hidden,
-            ]
-        );
+            $user->storage_used = (int) $updatedAccountSize;
+            $user->storage_used_updated_at = now();
+            $user->save();
 
-        $user->storage_used = (int) $updatedAccountSize;
-        $user->storage_used_updated_at = now();
-        $user->save();
+            return [$status, $media, $dm];
+        });
 
         if ($recipient->domain) {
             $this->remoteDeliver($dm);

--- a/app/Http/Controllers/InternalApiController.php
+++ b/app/Http/Controllers/InternalApiController.php
@@ -74,13 +74,16 @@ class InternalApiController extends Controller
             abort(403);
         }
 
-        $msg = DirectMessage::whereToId($profile->id)
-            ->orWhere('from_id', $profile->id)
+        $msg = DirectMessage::where(function ($query) use ($profile) {
+            $query->whereToId($profile->id)
+                ->orWhere('from_id', $profile->id);
+        })
             ->findOrFail($threadId);
 
-        $thread = DirectMessage::with('status')->whereIn('to_id', [$profile->id, $msg->from_id])
-            ->whereIn('from_id', [$profile->id, $msg->from_id])
-            ->orderBy('created_at', 'asc')
+        $counterpartId = $msg->from_id == $profile->id ? $msg->to_id : $msg->from_id;
+        $thread = DirectMessage::with('status')
+            ->betweenProfiles($profile->id, $counterpartId)
+            ->orderBy('id', 'asc')
             ->paginate(30);
 
         return response()->json(compact('msg', 'profile', 'thread'), 200, [], JSON_PRETTY_PRINT);

--- a/app/Jobs/DeletePipeline/DeleteRemoteStatusPipeline.php
+++ b/app/Jobs/DeletePipeline/DeleteRemoteStatusPipeline.php
@@ -12,6 +12,7 @@ use App\Mention;
 use App\Notification;
 use App\Report;
 use App\Services\Account\AccountStatService;
+use App\Services\DirectMessageService;
 use App\Services\NetworkTimelineService;
 use App\Services\StatusService;
 use App\Status;
@@ -79,7 +80,9 @@ class DeleteRemoteStatusPipeline implements ShouldQueue
             Notification::whereItemType('App\Status')
                 ->whereItemId($status->id)
                 ->forceDelete();
-            DirectMessage::whereStatusId($status->id)->delete();
+            DirectMessage::whereStatusId($status->id)->get()->each(function ($dm) {
+                DirectMessageService::deleteDm($dm);
+            });
             Like::whereStatusId($status->id)->forceDelete();
             MediaTag::whereStatusId($status->id)->delete();
             Media::whereStatusId($status->id)

--- a/app/Jobs/StatusPipeline/RemoteStatusDelete.php
+++ b/app/Jobs/StatusPipeline/RemoteStatusDelete.php
@@ -16,6 +16,7 @@ use App\Report;
 use App\Services\Account\AccountStatService;
 use App\Services\AccountService;
 use App\Services\CollectionService;
+use App\Services\DirectMessageService;
 use App\Services\NotificationService;
 use App\Services\StatusService;
 use App\Status;
@@ -140,14 +141,7 @@ class RemoteStatusDelete implements ShouldBeUniqueUntilProcessing, ShouldQueue
             });
         $dms = DirectMessage::whereStatusId($status->id)->get();
         foreach ($dms as $dm) {
-            $not = Notification::whereItemType('App\DirectMessage')
-                ->whereItemId($dm->id)
-                ->first();
-            if ($not) {
-                NotificationService::del($not->profile_id, $not->id);
-                $not->forceDeleteQuietly();
-            }
-            $dm->delete();
+            DirectMessageService::deleteDm($dm);
         }
         Like::whereStatusId($status->id)->forceDelete();
         Media::whereStatusId($status->id)

--- a/app/Jobs/StatusPipeline/StatusDelete.php
+++ b/app/Jobs/StatusPipeline/StatusDelete.php
@@ -6,6 +6,7 @@ use App\AccountInterstitial;
 use App\Bookmark;
 use App\CollectionItem;
 use App\DirectMessage;
+use App\Jobs\ActivityPub\PubDeliver;
 use App\Jobs\MediaPipeline\MediaDeletePipeline;
 use App\Like;
 use App\Media;
@@ -14,6 +15,7 @@ use App\Mention;
 use App\Notification;
 use App\Report;
 use App\Services\CollectionService;
+use App\Services\DirectMessageService;
 use App\Services\NotificationService;
 use App\Services\StatusService;
 use App\Status;
@@ -30,7 +32,6 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 use League\Fractal;
 use League\Fractal\Serializer\ArraySerializer;
-use App\Jobs\ActivityPub\PubDeliver;
 
 class StatusDelete implements ShouldQueue
 {
@@ -128,14 +129,7 @@ class StatusDelete implements ShouldQueue
 
         $dms = DirectMessage::whereStatusId($status->id)->get();
         foreach ($dms as $dm) {
-            $not = Notification::whereItemType('App\DirectMessage')
-                ->whereItemId($dm->id)
-                ->first();
-            if ($not) {
-                NotificationService::del($not->profile_id, $not->id);
-                $not->forceDeleteQuietly();
-            }
-            $dm->delete();
+            DirectMessageService::deleteDm($dm);
         }
         Like::whereStatusId($status->id)->delete();
 

--- a/app/Services/DirectMessageService.php
+++ b/app/Services/DirectMessageService.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Services;
+
+use App\DirectMessage;
+use App\Models\Conversation;
+use App\Notification;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class DirectMessageService
+{
+    public static function updateConversation(DirectMessage $dm, bool $force = false): void
+    {
+        if (! $force && Conversation::whereFromId($dm->from_id)
+            ->whereToId($dm->to_id)
+            ->where('dm_id', '>', $dm->id)
+            ->exists()) {
+            return;
+        }
+
+        Conversation::updateOrInsert(
+            ['from_id' => $dm->from_id, 'to_id' => $dm->to_id],
+            [
+                'dm_id' => $dm->id,
+                'status_id' => $dm->status_id,
+                'type' => $dm->type,
+                'is_hidden' => $dm->is_hidden,
+                'updated_at' => $dm->updated_at ?? now(),
+            ]
+        );
+    }
+
+    public static function reconcileDirection($fromId, $toId): ?DirectMessage
+    {
+        $latest = DirectMessage::query()
+            ->where('from_id', $fromId)
+            ->where('to_id', $toId)
+            ->whereHas('status')
+            ->orderByDesc('id')
+            ->first();
+
+        if (! $latest) {
+            Conversation::whereFromId($fromId)->whereToId($toId)->delete();
+
+            return null;
+        }
+
+        self::updateConversation($latest, true);
+
+        return $latest;
+    }
+
+    public static function reconcileBetween($firstProfileId, $secondProfileId): void
+    {
+        self::reconcileDirection($firstProfileId, $secondProfileId);
+        self::reconcileDirection($secondProfileId, $firstProfileId);
+    }
+
+    public static function deleteDm(DirectMessage $dm): void
+    {
+        $fromId = $dm->from_id;
+        $toId = $dm->to_id;
+
+        DB::transaction(function () use ($dm, $fromId, $toId) {
+            $notifications = Notification::whereItemType('App\\DirectMessage')
+                ->whereItemId($dm->id)
+                ->get();
+            foreach ($notifications as $notification) {
+                NotificationService::del($notification->profile_id, $notification->id);
+                $notification->forceDeleteQuietly();
+            }
+            $dm->delete();
+            self::reconcileBetween($fromId, $toId);
+        });
+    }
+
+    public static function logOrphan(DirectMessage $dm, ?int $conversationId = null): void
+    {
+        Log::warning('Direct message references a missing status', [
+            'dm_id' => $dm->id,
+            'status_id' => $dm->status_id,
+            'conversation_id' => $conversationId,
+            'from_id' => $dm->from_id,
+            'to_id' => $dm->to_id,
+        ]);
+    }
+}

--- a/database/migrations/2026_08_08_000000_add_direct_message_conversation_indexes.php
+++ b/database/migrations/2026_08_08_000000_add_direct_message_conversation_indexes.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('direct_messages', function (Blueprint $table) {
+            $table->index(['from_id', 'to_id', 'id'], 'direct_messages_from_to_id_index');
+            $table->index(['to_id', 'is_hidden', 'from_id', 'id'], 'direct_messages_inbox_index');
+        });
+
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->index(['from_id', 'to_id', 'dm_id'], 'conversations_from_to_dm_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('direct_messages', function (Blueprint $table) {
+            $table->dropIndex('direct_messages_from_to_id_index');
+            $table->dropIndex('direct_messages_inbox_index');
+        });
+
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->dropIndex('conversations_from_to_dm_index');
+        });
+    }
+};

--- a/tests/Feature/DirectMessageIntegrityTest.php
+++ b/tests/Feature/DirectMessageIntegrityTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\DirectMessage;
+use App\Models\Conversation;
+use App\Profile;
+use App\Services\DirectMessageService;
+use App\Status;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DirectMessageIntegrityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_between_profiles_applies_cursor_to_both_directions(): void
+    {
+        [$first, $second] = $this->makeProfiles();
+        $ids = [];
+
+        foreach (range(1, 24) as $index) {
+            $from = $index % 2 ? $first : $second;
+            $to = $index % 2 ? $second : $first;
+            $ids[] = $this->makeDm($from, $to)->id;
+        }
+
+        $firstPage = DirectMessage::betweenProfiles($first->id, $second->id)
+            ->orderByDesc('id')->limit(8)->pluck('id')->all();
+        $secondPage = DirectMessage::betweenProfiles($first->id, $second->id)
+            ->where('id', '<', min($firstPage))
+            ->orderByDesc('id')->limit(8)->pluck('id')->all();
+        $newer = DirectMessage::betweenProfiles($first->id, $second->id)
+            ->where('id', '>', max($secondPage))
+            ->orderBy('id')->pluck('id')->all();
+
+        $this->assertSame(array_reverse(array_slice($ids, 16, 8)), $firstPage);
+        $this->assertSame(array_reverse(array_slice($ids, 8, 8)), $secondPage);
+        $this->assertSame(array_slice($ids, 16, 8), $newer);
+        $this->assertSame([], array_values(array_intersect($firstPage, $secondPage)));
+    }
+
+    public function test_deleting_latest_dm_reconciles_conversation_and_deleting_all_removes_it(): void
+    {
+        [$first, $second] = $this->makeProfiles();
+        $older = $this->makeDm($first, $second);
+        $latest = $this->makeDm($first, $second);
+        DirectMessageService::updateConversation($latest);
+
+        DirectMessageService::deleteDm($latest);
+
+        $conversation = Conversation::whereFromId($first->id)->whereToId($second->id)->firstOrFail();
+        $this->assertSame((string) $older->id, (string) $conversation->dm_id);
+        $this->assertSame((string) $older->status_id, (string) $conversation->status_id);
+
+        DirectMessageService::deleteDm($older);
+        $this->assertFalse(Conversation::whereFromId($first->id)->whereToId($second->id)->exists());
+    }
+
+    public function test_inbox_limit_is_applied_after_conversation_deduplication(): void
+    {
+        $owner = $this->makeProfile('owner');
+        $senders = collect(['a', 'b', 'c', 'd'])->map(fn ($name) => $this->makeProfile($name));
+
+        foreach ([50, 10, 10, 10] as $index => $count) {
+            foreach (range(1, $count) as $unused) {
+                $this->makeDm($senders[$index], $owner);
+            }
+        }
+
+        $ranked = DirectMessage::query()
+            ->select('direct_messages.*')
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY from_id ORDER BY id DESC) AS conversation_rank')
+            ->whereToId($owner->id)
+            ->whereIsHidden(false)
+            ->whereHas('status');
+
+        $conversations = DirectMessage::query()
+            ->fromSub($ranked, 'direct_messages')
+            ->where('conversation_rank', 1)
+            ->orderByDesc('id')
+            ->limit(8)
+            ->get();
+
+        $this->assertCount(4, $conversations);
+        $this->assertCount(4, $conversations->unique('from_id'));
+    }
+
+    public function test_repair_command_reports_then_removes_orphan_dm(): void
+    {
+        [$first, $second] = $this->makeProfiles();
+        $dm = $this->makeDm($first, $second);
+        DirectMessageService::updateConversation($dm);
+        Status::whereKey($dm->status_id)->forceDelete();
+
+        $this->artisan('pixelfed:repair-direct-messages --dry-run')->assertSuccessful();
+        $this->assertDatabaseHas('direct_messages', ['id' => $dm->id]);
+
+        $this->artisan('pixelfed:repair-direct-messages')->assertSuccessful();
+        $this->assertDatabaseMissing('direct_messages', ['id' => $dm->id]);
+        $this->assertDatabaseMissing('conversations', ['from_id' => $first->id, 'to_id' => $second->id]);
+    }
+
+    private function makeDm(Profile $from, Profile $to): DirectMessage
+    {
+        $status = new Status;
+        $status->profile_id = $from->id;
+        $status->caption = 'test message';
+        $status->rendered = 'test message';
+        $status->scope = 'direct';
+        $status->visibility = 'direct';
+        $status->in_reply_to_profile_id = $to->id;
+        $status->save();
+
+        $dm = new DirectMessage;
+        $dm->from_id = $from->id;
+        $dm->to_id = $to->id;
+        $dm->status_id = $status->id;
+        $dm->type = 'text';
+        $dm->is_hidden = false;
+        $dm->save();
+
+        return $dm;
+    }
+
+    private function makeProfiles(): array
+    {
+        return [$this->makeProfile('first'), $this->makeProfile('second')];
+    }
+
+    private function makeProfile(string $name): Profile
+    {
+        $profile = new Profile;
+        $profile->username = 'dm-'.$name.'-'.bin2hex(random_bytes(4));
+        $profile->save();
+
+        return $profile;
+    }
+}


### PR DESCRIPTION
## Contexto
Este PR corrige inconsistências no fluxo de mensagens diretas que podiam gerar referências órfãs, metadados de conversa desatualizados e diferenças de comportamento entre bancos (principalmente PostgreSQL).

## O que foi alterado
- Centralização da lógica de integridade de DMs em um serviço dedicado (DirectMessageService), incluindo:
  - atualização de conversa com a última DM válida
  - reconciliação bidirecional entre perfis
  - remoção segura de DM com limpeza associada
- Fortalecimento do modelo de DM:
  - validação para impedir DM sem status válido
  - atualização/reconciliação automática de conversa em eventos de save/delete
  - escopo betweenProfiles para consultas entre dois perfis
- Refatoração de consultas e listagens de conversa em controladores para reduzir inconsistências e melhorar comportamento no PostgreSQL.
- Ajustes nos pipelines de remoção de status para usar exclusão de DM com reconciliação.
- Inclusão do comando de manutenção para diagnóstico/reparo de inconsistências:
  - pixelfed:repair-direct-messages
- Adição de índices para otimizar consultas de DM/conversa.
- Adição de testes de integridade de DM e paginação.
- Adição de job no CI para rodar o teste de integridade de DM em PostgreSQL.

## Impacto esperado
- Menor chance de DMs órfãs e conversas com ponteiros inválidos.
- Comportamento mais previsível entre MySQL e PostgreSQL.
- Melhor performance de leitura em consultas de inbox/thread por conta dos índices.

## Migração e operação
- Executar migrations para criação dos novos índices.
- Opcional após deploy: executar pixelfed:repair-direct-messages --dry-run para diagnóstico inicial.

## Validação
- Testes de integridade de DM passando em ambiente local.
- Teste específico de integridade executado no CI com PostgreSQL.